### PR TITLE
pass options through to dat, overriding defaults

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,16 @@ var archive = new DatArchive(datURL, {
 })
 ```
 
-You can also pass options through to Dat with `datOptions`:
+You can also pass options through to [dat-node](https://github.com/datproject/dat-node) with `datOptions`, or pass options to its `.joinNetwork([opts])` method with `netOptions`:
 
 ```js
 var archive = new DatArchive(datURL, {
   localPath: './my-archive-data',
   datOptions: {
     live: true
+  },
+  netOptions: {
+    upload: false
   }
 })
 ```

--- a/README.md
+++ b/README.md
@@ -44,6 +44,19 @@ var archive = new DatArchive(datURL, {
 })
 ```
 
+You can also pass options through to Dat with `datOptions`:
+
+```js
+var archive = new DatArchive(datURL, {
+  localPath: './my-archive-data',
+  datOptions: {
+    live: true
+  }
+})
+```
+
+This will extend node-dat-archive's defaults.
+
 ### Differences from Browser API
 
  - This module adds the `localPath` parameter to `new DatArchive` and `DatArchive.create`. Use the `localPath` to specify where the data for the archive should be stored. If not provided, the archive will be stored in memory.

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const to = (opts) =>
     : DEFAULT_DAT_API_TIMEOUT
 
 class DatArchive {
-  constructor (url, {localPath, latest} = {}) {
+  constructor (url, {localPath, latest, datOptions} = {}) {
     latest = latest || false
 
     // parse URL
@@ -41,6 +41,12 @@ class DatArchive {
     this._loadPromise = new Promise((resolve, reject) => {
       // TODO resolve DNS
       const temp = !localPath
+      let options = urlp ? {key: urlp.hostname, sparse: true, latest, temp} : {indexing: false, latest, temp}
+      if (datOptions) {
+        Object.keys(datOptions).forEach((key) => {
+          options[key] = datOptions[key]
+        })
+      }
       Dat(localPath || ram, urlp ? {key: urlp.hostname, sparse: true, latest, temp} : {indexing: false, latest, temp}, async (err, dat) => {
         if (err) {
           return reject(err)

--- a/index.js
+++ b/index.js
@@ -26,7 +26,7 @@ const to = (opts) =>
     : DEFAULT_DAT_API_TIMEOUT
 
 class DatArchive {
-  constructor (url, {localPath, latest, datOptions} = {}) {
+  constructor (url, {localPath, latest, datOptions, netOptions} = {}) {
     latest = latest || false
 
     // parse URL
@@ -51,7 +51,7 @@ class DatArchive {
         if (err) {
           return reject(err)
         }
-        dat.joinNetwork()
+        dat.joinNetwork(netOptions || {})
         this.url = this.url || `dat://${dat.archive.key.toString('hex')}`
         this._archive = dat.archive
         this._checkout = (this._version) ? dat.archive.checkout(this._version) : dat.archive


### PR DESCRIPTION
This commit addresses issue https://github.com/beakerbrowser/node-dat-archive/issues/1 by overriding Dat option defaults with values from the `datOptions` attribute of the options dash.