### PR TITLE
Add `dat-dns` to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "beaker-error-constants": "^1.2.0",
     "concat-stream": "^1.6.0",
+    "dat-dns": "^2.0.0",
     "dat-node": "^3.5.3",
     "dom-event-target": "^1.0.0",
     "parse-dat-url": "^3.0.1",


### PR DESCRIPTION
The `dat-dns` module is used in util.js, but not explicitly listed as a dependency. This might become a problem if someone decides to use this module outside of Beaker.