### PR TITLE
Fix: update `.configure` and `.getInfo` to match Beaker

### DIFF
--- a/index.js
+++ b/index.js
@@ -124,7 +124,16 @@ class DatArchive {
   async configure (settings) {
     await this._loadPromise
     if (!settings || typeof settings !== 'object') throw new Error('Invalid argument')
-    if ('title' in settings || 'description' in settings || 'type' in settings || 'author' in settings) {
+    const knownProps = [
+      'author',
+      'description',
+      'fallback_page',
+      'links',
+      'title',
+      'type',
+      'web_root'
+    ]
+    if (knownProps.filter(prop => prop in settings).length > 0) {
       await pda.updateManifest(this._archive, settings)
     }
     if ('networked' in settings) {

--- a/index.js
+++ b/index.js
@@ -169,7 +169,8 @@ class DatArchive {
         title: manifest.title,
         description: manifest.description,
         type: manifest.type,
-        author: manifest.author
+        author: manifest.author,
+        links: manifest.links
       }
     })
   }

--- a/test/api.js
+++ b/test/api.js
@@ -155,7 +155,8 @@ test('archive.configure', async t => {
     title: 'The New Title',
     description: 'The New Description',
     type: ['dataset', 'foo'],
-    author: {name: 'Robert', url: 'dat://ffffffffffffffffffffffffffffffff'}
+    author: {name: 'Robert', url: 'dat://ffffffffffffffffffffffffffffffff'},
+    links: { prev: [{ href: 'dat://example.com' }] }
   })
 
   // check the dat.json
@@ -164,6 +165,7 @@ test('archive.configure', async t => {
   t.deepEqual(manifest.description, 'The New Description')
   t.deepEqual(manifest.type, ['dataset', 'foo'])
   t.deepEqual(manifest.author, {name: 'Robert', url: 'dat://ffffffffffffffffffffffffffffffff'})
+  t.deepEqual(manifest.links, { prev: [{ href: 'dat://example.com' }] })
 })
 
 test('archive.writeFile', async t => {


### PR DESCRIPTION
The [DatArchive.prototype.configure](https://beakerbrowser.com/docs/apis/dat#configure) method recognizes a number of parameters not observed by node-dat-archive. This patch fixes that, causing the `.configure` method to recognize all parameters currently observed in Beaker's implementation. `.getInfo` likewise now matches Beaker's return object.